### PR TITLE
Partial changes to complete the initial handshake with gdb client. (#51)

### DIFF
--- a/llvm-15.0.3/lldb/include/lldb/Utility/StringExtractorGDBRemote.h
+++ b/llvm-15.0.3/lldb/include/lldb/Utility/StringExtractorGDBRemote.h
@@ -66,6 +66,7 @@ public:
     eServerPacketType_qUserName,
     eServerPacketType_qGetWorkingDir,
     eServerPacketType_qFileLoadAddress,
+    eServerPacketType_qOffsets,
     eServerPacketType_QEnvironment,
     eServerPacketType_QEnableErrorStrings,
     eServerPacketType_QLaunchArch,

--- a/llvm-15.0.3/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
+++ b/llvm-15.0.3/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
@@ -849,6 +849,8 @@ GDBRemoteCommunicationServerLLGS::PrepareStopReplyPacketForThread(
     response.PutChar(';');
   }
 
+#if 0 // TODO: Uncomment after fixing corefile register handling.
+
   // If a 'QListThreadsInStopReply' was sent to enable this feature, we will
   // send all thread IDs back in the "threads" key whose value is a list of hex
   // thread IDs separated by commas:
@@ -992,6 +994,7 @@ GDBRemoteCommunicationServerLLGS::PrepareStopReplyPacketForThread(
                     tid_stop_info.details.fork.child_pid,
                     tid_stop_info.details.fork.child_tid);
   }
+#endif
 
   return response;
 }

--- a/llvm-15.0.3/lldb/source/Utility/StringExtractorGDBRemote.cpp
+++ b/llvm-15.0.3/lldb/source/Utility/StringExtractorGDBRemote.cpp
@@ -239,6 +239,11 @@ StringExtractorGDBRemote::GetServerPacketType() const {
         return eServerPacketType_qMemTags;
       break;
 
+    case 'O':
+        if (PACKET_MATCHES("qOffsets"))
+          return eServerPacketType_qOffsets;
+        break;
+
     case 'P':
       if (PACKET_STARTS_WITH("qProcessInfoPID:"))
         return eServerPacketType_qProcessInfoPID;

--- a/llvm-15.0.3/lldb/tools/lldb-crash-server/CMakeLists.txt
+++ b/llvm-15.0.3/lldb/tools/lldb-crash-server/CMakeLists.txt
@@ -46,6 +46,8 @@ add_lldb_tool(lldb-crash-server
     SystemInitializerLLGS.cpp
     CoreFile.cpp
     GDBRemoteCommunicationServerCS.cpp
+    CoreFileProtocol.cpp
+    CoreThreadProtocol.cpp
 
     LINK_LIBS
       lldbHost

--- a/llvm-15.0.3/lldb/tools/lldb-crash-server/CoreFile.h
+++ b/llvm-15.0.3/lldb/tools/lldb-crash-server/CoreFile.h
@@ -126,6 +126,8 @@ public:
   unsigned getNumOfFrames() { return NumOfFrames; }
 
   lldb::SBTarget &getTarget() { return target; }
+
+  lldb::SBProcess &getProcess() { return process; }
 };
 
 } // namespace lldb_crash_analyzer

--- a/llvm-15.0.3/lldb/tools/lldb-crash-server/CoreFileProtocol.cpp
+++ b/llvm-15.0.3/lldb/tools/lldb-crash-server/CoreFileProtocol.cpp
@@ -1,0 +1,62 @@
+//===- CoreFileProtocol.cpp --------------------------------------*- C++ -*===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ADT/Triple.h"
+#include "lldb/API/SBThread.h"
+#include "lldb/Utility/ArchSpec.h"
+#include "Plugins/Process/Linux/NativeThreadLinux.h"
+
+#include "CoreFileProtocol.h"
+#include "CoreThreadProtocol.h"
+
+using namespace lldb_private;
+using namespace process_gdb_remote;
+using namespace process_linux;
+
+CoreFileProtocol::CoreFileProtocol(::pid_t pid,
+                 NativeProcessProtocol::NativeDelegate &delegate,
+                 const ArchSpec &arch,
+                 MainLoop &mainloop, llvm::ArrayRef<::pid_t> tids)
+    : NativeProcessELF(pid, -1, delegate), m_arch(arch), m_main_loop(mainloop) {
+  Status status;
+  for (const auto &tid : tids) {
+    AddThread(tid);
+  }
+  SetCurrentThreadID(tids[0]);
+  SetState(lldb::StateType::eStateStopped, false);
+}
+
+llvm::Expected<std::unique_ptr<CoreFileProtocol>>
+CoreFileProtocol::Factory::Read(lldb::crash_analyzer::CoreFile &corefile, 
+                                NativeProcessProtocol::NativeDelegate &native_delegate,
+                                MainLoop &mainloop) const {
+    // Read the architecture from the core.
+    std::string TargetTripleString = corefile.getTarget().GetTriple();
+    llvm::Triple TheTriple(llvm::Triple::normalize(TargetTripleString));
+    lldb_private::ArchSpec Arch(TheTriple.normalize());
+    
+    // Get the pid and the tids.
+    auto process = corefile.getProcess();
+    ::pid_t pid = process.GetProcessID();
+    uint32_t numThreads = process.GetNumThreads();
+    std::vector<::pid_t> tids;
+    tids.reserve(numThreads);
+
+    for (unsigned int i = 0; i < numThreads; i++) {
+        lldb::SBThread thread = process.GetThreadAtIndex(i);
+	tids.push_back(thread.GetThreadID());
+    }
+
+    return std::unique_ptr<CoreFileProtocol>(new CoreFileProtocol(
+       pid, native_delegate, Arch, mainloop, tids));
+}
+
+void
+CoreFileProtocol::AddThread(lldb::tid_t tid) {
+    m_threads.push_back(std::make_unique<CoreThreadProtocol>(*this, tid));
+}

--- a/llvm-15.0.3/lldb/tools/lldb-crash-server/CoreFileProtocol.h
+++ b/llvm-15.0.3/lldb/tools/lldb-crash-server/CoreFileProtocol.h
@@ -1,0 +1,70 @@
+//===- CoreFileProtocol.h ----------------------------------------*- C++ -*===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_CRASH_SERVER_COREFILE_PROTOCOL_H
+#define LLDB_CRASH_SERVER_COREFILE_PROTOCOL_H
+
+#include "CoreFile.h"
+#include "lldb/Host/common/NativeProcessProtocol.h"
+#include "Plugins/Process/POSIX/NativeProcessELF.h"
+#include "Plugins/Process/Utility/NativeProcessSoftwareSingleStep.h"
+
+namespace lldb_private {
+
+namespace process_gdb_remote {
+
+class CoreFileProtocol : public NativeProcessELF {
+public:
+  Status Resume(const ResumeActionList &resume_actions) override { return Status(); }
+  Status Halt() override { return Status(); }
+  Status Detach() override { return Status(); }
+  Status Signal(int signo) override { return Status(); }
+  Status Kill() override { return Status(); }
+  Status ReadMemory(lldb::addr_t addr, void *buf, size_t size,
+                    size_t &bytes_read) override { return Status(); }
+  Status WriteMemory(lldb::addr_t addr, const void *buf, size_t size,
+                     size_t &bytes_written) override { return Status(); }
+  size_t UpdateThreads() override { return 0; }
+  const ArchSpec &GetArchitecture() const override { return m_arch; }
+  Status SetBreakpoint(lldb::addr_t addr, uint32_t size,
+                       bool hardware) override {
+    return Status();
+  }
+  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
+  GetAuxvData() const override { return make_error_code(llvm::errc::not_supported); }
+  Status GetLoadedModuleFileSpec(const char *module_path,
+                                 FileSpec &file_spec) override {
+    return Status();
+  }
+  Status GetFileLoadAddress(const llvm::StringRef &file_name,
+                            lldb::addr_t &load_addr) override {
+    return Status();
+  }
+  class Factory {
+  public:
+    llvm::Expected<std::unique_ptr<CoreFileProtocol>>
+    Read(lldb::crash_analyzer::CoreFile &corefile,
+         NativeProcessProtocol::NativeDelegate &native_delegate,
+         MainLoop &mainloop) const;
+
+}; // CoreFileProtocol::Factory
+
+private:
+  ArchSpec m_arch;
+  MainLoop &m_main_loop;
+
+  CoreFileProtocol(::pid_t pid, NativeProcessProtocol::NativeDelegate &delegate,
+                   const ArchSpec &arch, MainLoop &mainloop,
+                   llvm::ArrayRef<::pid_t> tids);
+  void AddThread(lldb::tid_t tid);
+}; // CoreFileProtocol
+
+} // namespace process_gdb_remote
+} // namespace lldb_private
+
+#endif // LLDB_CRASH_SERVER_COREFILE_PROTOCOL_H 

--- a/llvm-15.0.3/lldb/tools/lldb-crash-server/CoreRegisterContext.h
+++ b/llvm-15.0.3/lldb/tools/lldb-crash-server/CoreRegisterContext.h
@@ -1,0 +1,32 @@
+//===- CoreRegisterContext.h -------------------------------------*- C++ -*===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef COREREGISTERCONTEXT_H
+#define COREREGISTERCONTEXT_H
+
+#include "lldb/Host/common/NativeThreadProtocol.h"
+#include "lldb/Host/common/NativeRegisterContext.h"
+
+namespace lldb_private {
+
+class CoreRegisterContext : public NativeRegisterContext {
+public:
+  CoreRegisterContext(NativeThreadProtocol &thread) : NativeRegisterContext(thread) {}
+  ~CoreRegisterContext() {}
+  uint32_t GetRegisterCount() const override { return 42; }
+  uint32_t GetUserRegisterCount() const override { return 42; }
+  const RegisterInfo *GetRegisterInfoAtIndex(uint32_t reg) const override { return NULL; }
+  uint32_t GetRegisterSetCount() const override { return 42; }
+  const RegisterSet *GetRegisterSet(uint32_t set_index) const override { return NULL; }
+  Status ReadRegister(const RegisterInfo *reg_info, RegisterValue &reg_value) override { return Status(); }
+  Status WriteRegister(const RegisterInfo *reg_info, const RegisterValue &reg_value) override { return Status(); }
+  Status ReadAllRegisterValues(lldb::WritableDataBufferSP &data_sp) override { return Status(); }
+  Status WriteAllRegisterValues(const lldb::DataBufferSP &data_sp) override { return Status(); }
+};
+} // namespace lldb_private
+#endif

--- a/llvm-15.0.3/lldb/tools/lldb-crash-server/CoreThreadProtocol.cpp
+++ b/llvm-15.0.3/lldb/tools/lldb-crash-server/CoreThreadProtocol.cpp
@@ -1,0 +1,24 @@
+//===- CoreThreadProtocol.cpp -------------------------------------*- C++ -*===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CoreThreadProtocol.h"
+#include <csignal>
+
+using namespace lldb_private;
+using namespace lldb_private::process_gdb_remote;
+
+bool
+CoreThreadProtocol::GetStopReason(ThreadStopInfo &stop_info,
+                                  std::string &description) {
+  description = "signal";
+
+  stop_info.reason = lldb::StopReason::eStopReasonSignal;
+  stop_info.signo = SIGSEGV;
+  return true;
+}
+

--- a/llvm-15.0.3/lldb/tools/lldb-crash-server/CoreThreadProtocol.h
+++ b/llvm-15.0.3/lldb/tools/lldb-crash-server/CoreThreadProtocol.h
@@ -1,0 +1,40 @@
+//===- CoreThreadProtocol.h ---------------------------------------*- C++ -*===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CORETHREADPROTOCOL_H
+#define CORETHREADPROTOCOL_H
+
+#include "CoreRegisterContext.h"
+
+namespace lldb_private {
+
+namespace process_gdb_remote {
+  class CoreThreadProtocol : public NativeThreadProtocol {
+  public:
+    CoreThreadProtocol(NativeProcessProtocol &process, lldb::tid_t tid)
+       : NativeThreadProtocol(process, tid) { m_reg_context_up = std::make_unique<CoreRegisterContext>(*this); }
+    std::string GetName() override { return ""; }
+    lldb::StateType GetState() override { return lldb::StateType::eStateStopped; }
+    NativeRegisterContext &GetRegisterContext() override { return *m_reg_context_up; }
+    bool GetStopReason(ThreadStopInfo &stop_info, std::string &description) override;
+    Status SetWatchpoint(lldb::addr_t addr, size_t size, uint32_t watch_flags,
+                         bool hardware) override { return Status(); }
+    Status RemoveWatchpoint(lldb::addr_t addr)
+                         override { return Status(); }
+    Status SetHardwareBreakpoint(lldb::addr_t addr, size_t size) override
+      { return Status(); }
+                                
+    Status RemoveHardwareBreakpoint(lldb::addr_t addr) override
+      { return Status(); }
+
+  private:
+    std::unique_ptr<CoreRegisterContext> m_reg_context_up;
+  };
+} // process_gdb_remote
+} // lldb_private
+#endif

--- a/llvm-15.0.3/lldb/tools/lldb-crash-server/GDBRemoteCommunicationServerCS.h
+++ b/llvm-15.0.3/lldb/tools/lldb-crash-server/GDBRemoteCommunicationServerCS.h
@@ -10,6 +10,7 @@
 
 #include "Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.h"
 #include "CoreFile.h"
+#include "CoreFileProtocol.h"
 
 namespace lldb_private {
 
@@ -21,7 +22,9 @@ public:
   GDBRemoteCommunicationServerLLCS(
     MainLoop &mainloop,
     const NativeProcessProtocol::Factory &process_factory) : 
-  GDBRemoteCommunicationServerLLGS(mainloop, process_factory) {};
+  GDBRemoteCommunicationServerLLGS(mainloop, process_factory){
+     RegisterPacketHandlers_LLCS();
+  };
 
   Status ReadCoreFile(
     const std::string &core_file,
@@ -30,9 +33,24 @@ public:
     const std::string solib_path,
     llvm::ArrayRef<llvm::StringRef> Arguments
     );
+
+  std::unique_ptr<lldb::crash_analyzer::CoreFile>& getCoreFile() {
+    return m_corefile;
+  }
+  
+  Status CreateProcessContext();
+
+  void RegisterPacketHandlers_LLCS();
+
+  PacketResult Handle_qC_LLCS(StringExtractorGDBRemote &packet);
+
+  PacketResult Handle_qOffsets_LLCS(StringExtractorGDBRemote &packet);
+
 protected:
 private:
-  std::unique_ptr<lldb::crash_analyzer::CoreFile> corefile;
+  std::unique_ptr<lldb::crash_analyzer::CoreFile> m_corefile;
+  std::unique_ptr<CoreFileProtocol::Factory> m_corefile_factory;
+  llvm::StringRef m_progname;
 };
 
 } // namespace process_gdb_remote


### PR DESCRIPTION
* Create copy of lldb-server with name lldb-crash-server.

* Modify CMake files to build the crash server.

* Integrate the core file reader into the crash server.

* Renamed CoreGDBRemote.{h,cpp} to CoreFile.{h,cpp}. Made required changes for this in CMakeLists and in other sources.

* Code for creating the initial process context. The ptid is created from the core and transmitted to gdb. gdb bails because we don't have not implemented the code to read the registers from the core file.

* TEMPORARY change - this SHOULD BE REVERTED when the register handling code is ready. Having the register retrieval code here without the underlying low-level code causes a crash.